### PR TITLE
Fine tune max number of workers for thread pool in gmail gateway

### DIFF
--- a/gmail_fisher/gmail_gateway.py
+++ b/gmail_fisher/gmail_gateway.py
@@ -60,7 +60,7 @@ class GmailClient:
 class GmailGateway:
     """Maximum number of workers for thread pool executor"""
 
-    MAX_WORKERS: Final[int] = 20
+    THREAD_POOL_MAX_WORKERS: Final[int] = 200
 
     @classmethod
     def __list_message_ids(
@@ -171,7 +171,7 @@ class GmailGateway:
         message_ids = GmailGateway.__list_message_ids(
             sender_emails, keywords, max_results
         )
-        with ThreadPoolExecutor(max_workers=cls.MAX_WORKERS) as pool:
+        with ThreadPoolExecutor(max_workers=cls.THREAD_POOL_MAX_WORKERS) as pool:
             logger.info(f"Submitting {len(message_ids)} tasks to thread pool")
             futures = [
                 pool.submit(GmailGateway.__get_message_detail, message_id, fetch_body)
@@ -193,7 +193,7 @@ class GmailGateway:
 
     @classmethod
     def run_batch_save_pdf_attachments(cls, messages: Iterable[GmailMessage]):
-        with ThreadPoolExecutor(max_workers=20) as pool:
+        with ThreadPoolExecutor(max_workers=cls.THREAD_POOL_MAX_WORKERS) as pool:
             future_mappings = {}
             for message in messages:
                 for attachment in message.attachments:


### PR DESCRIPTION
5 minute test for fine-tuning the maximum number of workers for thread pool executor:

```
max_workers = 20  ./export_expenses.sh gmail_fisher/output/food_expenses.json   8.57s user 1.25s system 90% cpu 10.883 total
max_workers = 100 ./export_expenses.sh gmail_fisher/output/food_expenses.json   7.21s user 1.83s system 167% cpu 5.409 total
max_workers = 200 ./export_expenses.sh gmail_fisher/output/food_expenses.json   6.70s user 1.20s system 155% cpu 5.087 total
max_workers = 250 ./export_expenses.sh gmail_fisher/output/food_expenses.json   7.12s user 1.73s system 158% cpu 5.592 total
max_workers = 300 ./export_expenses.sh gmail_fisher/output/food_expenses.json   7.39s user 1.99s system 157% cpu 5.976 total
```